### PR TITLE
[Fix] selected notes bg color

### DIFF
--- a/dist/dist.css
+++ b/dist/dist.css
@@ -40,6 +40,7 @@
   --sn-desktop-titlebar-ui-hover-color: var(--highlight-color);
   --sn-stylekit-scrollbar-track-border-color: var(--border-color);
   --sn-stylekit-scrollbar-thumb-color: var(--sn-stylekit-info-color);
+  --sn-stylekit-grey-5: #e95379;
 }
 
 /*# sourceMappingURL=dist.css.map */


### PR DESCRIPTION
The line in Standard Notes source code setting this color is [here](https://github.com/standardnotes/web/blob/a1c7ad7d7e16a8cb35f72411e598400cf8f4b616/app/assets/stylesheets/_notes.scss#L302). Official themes set this color to control the bg color when we select a note. For example, look [here](https://github.com/standardnotes/web/blob/a1c7ad7d7e16a8cb35f72411e598400cf8f4b616/public/components/org.standardnotes.theme-midnight/dist/dist.css#L42) to check how _Midnight_ does the same. So I believe this PR fixes #2

@luisstd I cannot test this locally without hosting the dist somewhere. If you have an option to test it, please let me know if there are any issues with the fix. Thanks!